### PR TITLE
都道府県別人口をAPIから取得する中間APIを追加

### DIFF
--- a/src/app/api/population/[prefCode]/populationFetcher.ts
+++ b/src/app/api/population/[prefCode]/populationFetcher.ts
@@ -1,0 +1,41 @@
+import { type Population } from '@/types/population';
+
+interface RESASPopulationResponse {
+  message: null;
+  result: {
+    boundaryYear: number;
+    data: Population[];
+  };
+}
+
+export async function fetchPopulation(prefCode: number): Promise<Population[] | undefined> {
+  const API_URL = process.env.RESAS_URL;
+  const API_KEY = process.env.RESAS_API_KEY;
+
+  if (API_URL === undefined) throw new Error('RESAS_URL is not defined');
+  if (API_KEY === undefined) throw new Error('RESAS_API_KEY is not defined');
+
+  const url = new URL('/api/v1/population/composition/perYear', API_URL);
+  url.searchParams.set('prefCode', prefCode.toString());
+  url.searchParams.set('cityCode', '-');
+
+  const requestInit: RequestInit = {
+    headers: { 'X-API-KEY': API_KEY },
+  };
+
+  const populations = await fetch(url.toString(), requestInit)
+    .then(async (res) => {
+      if (!res.ok) throw new Error(`HTTP status code: ${res.status}`);
+      return await res.json();
+    })
+    .then((prefectureResponse) => {
+      const response: RESASPopulationResponse = prefectureResponse;
+      return response.result.data;
+    })
+    .catch((error) => {
+      console.error(error);
+      return undefined;
+    });
+
+  return populations;
+}

--- a/src/app/api/population/[prefCode]/route.test.ts
+++ b/src/app/api/population/[prefCode]/route.test.ts
@@ -1,0 +1,48 @@
+import { type NextRequest } from 'next/server';
+import { GET } from './route';
+import { POPULATION_TYPES } from '@/consts/populations';
+import { type PopulationResponse } from '@/types/population';
+
+describe('api /api/prefectures', () => {
+  test('全てのタイプを返すか', async () => {
+    const partialReq: Partial<NextRequest> = {};
+    const mockReq = partialReq as NextRequest;
+    const params = {
+      prefCode: '1',
+    };
+
+    const response = await GET(mockReq, { params });
+
+    expect(response.status).toBe(200);
+
+    const prefecturesResponse: PopulationResponse = await response.json();
+
+    // 全てのタイプが含まれている
+    const populationTypes = prefecturesResponse.populations.map((population) => population.label);
+    expect(populationTypes).toEqual(POPULATION_TYPES);
+  });
+
+  test('prefCode が範囲外の時 400 を返すか', async () => {
+    const partialReq: Partial<NextRequest> = {};
+    const mockReq = partialReq as NextRequest;
+    const params = {
+      prefCode: '65536',
+    };
+
+    const response = await GET(mockReq, { params });
+
+    expect(response.status).toBe(400);
+  });
+
+  test('prefCode が数字でない場合 400 を返すか', async () => {
+    const partialReq: Partial<NextRequest> = {};
+    const mockReq = partialReq as NextRequest;
+    const params = {
+      prefCode: 'a',
+    };
+
+    const response = await GET(mockReq, { params });
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/src/app/api/population/[prefCode]/route.ts
+++ b/src/app/api/population/[prefCode]/route.ts
@@ -1,0 +1,20 @@
+import { type NextApiRequest } from 'next';
+import { NextResponse } from 'next/server';
+import { fetchPopulation } from './populationFetcher';
+
+export async function GET(_req: NextApiRequest, { params }: { params: { prefCode: string } }): Promise<NextResponse> {
+  const { prefCode: prefCodeStr } = params;
+  const prefCode = parseInt(prefCodeStr ?? '', 10);
+
+  if (Number.isNaN(prefCode)) {
+    return NextResponse.json({ message: 'Bad Request' }, { status: 400 });
+  }
+
+  const populations = await fetchPopulation(prefCode);
+
+  if (populations === undefined) {
+    return NextResponse.json({ message: 'Internal Server Error' }, { status: 500 });
+  }
+
+  return NextResponse.json({ populations }, { status: 200 });
+}

--- a/src/app/api/population/[prefCode]/route.ts
+++ b/src/app/api/population/[prefCode]/route.ts
@@ -1,19 +1,19 @@
-import { type NextApiRequest } from 'next';
+import { type NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { fetchPopulation } from './populationFetcher';
 
-export async function GET(_req: NextApiRequest, { params }: { params: { prefCode: string } }): Promise<NextResponse> {
+export async function GET(_req: NextRequest, { params }: { params: { prefCode: string } }): Promise<NextResponse> {
   const { prefCode: prefCodeStr } = params;
   const prefCode = parseInt(prefCodeStr ?? '', 10);
 
   if (Number.isNaN(prefCode)) {
-    return NextResponse.json({ message: 'Bad Request' }, { status: 400 });
+    return NextResponse.json({ message: 'Bad Request. Please specify a number.' }, { status: 400 });
   }
 
   const populations = await fetchPopulation(prefCode);
 
   if (populations === undefined) {
-    return NextResponse.json({ message: 'Internal Server Error' }, { status: 500 });
+    return NextResponse.json({ message: 'Bad Request. Please specify prefCode.' }, { status: 400 });
   }
 
   return NextResponse.json({ populations }, { status: 200 });

--- a/src/consts/populations.ts
+++ b/src/consts/populations.ts
@@ -1,0 +1,1 @@
+export const POPULATION_TYPES = ['総人口', '年少人口', '生産年齢人口', '老年人口'] as const;

--- a/src/types/population.ts
+++ b/src/types/population.ts
@@ -1,0 +1,11 @@
+export interface YearPopulation {
+  year: number;
+  value: number;
+}
+
+export type PopulationType = '総人口' | '年少人口' | '生産年齢人口' | '老年人口';
+
+export interface Population {
+  label: PopulationType;
+  data: YearPopulation[];
+}

--- a/src/types/population.ts
+++ b/src/types/population.ts
@@ -1,11 +1,17 @@
+import { type POPULATION_TYPES } from '@/consts/populations';
+
 export interface YearPopulation {
   year: number;
   value: number;
 }
 
-export type PopulationType = '総人口' | '年少人口' | '生産年齢人口' | '老年人口';
+export type PopulationType = (typeof POPULATION_TYPES)[number];
 
 export interface Population {
   label: PopulationType;
   data: YearPopulation[];
+}
+
+export interface PopulationResponse {
+  populations: Population[];
 }


### PR DESCRIPTION
Closes https://github.com/SatooRu65536/yumemi-codingtest/issues/23

## 説明
都道府県別人口をAPIから取得する中間APIを作成した

## 更新前の動作
なし

## 更新後の動作


## 追加情報
