### PR TITLE
都道府県を未選択時にメッセージを表示

### DIFF
--- a/src/app/_components/ChartSection/Chart/index.module.scss
+++ b/src/app/_components/ChartSection/Chart/index.module.scss
@@ -7,7 +7,24 @@
     text-align: center;
   }
 
-  & > div:has([class*='highcharts-container']) {
+  & > .chart_container {
     height: 600px;
+    position: relative;
+
+    .message_area {
+      margin: auto;
+      background-color: $color-background;
+      text-align: center;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      position: absolute;
+      inset: 0;
+      z-index: 1;
+    }
+
+    div:has([class*='highcharts-container']) {
+      height: 100%;
+    }
   }
 }

--- a/src/app/_components/ChartSection/Chart/index.test.tsx
+++ b/src/app/_components/ChartSection/Chart/index.test.tsx
@@ -81,4 +81,20 @@ describe('components Header', () => {
 
     expect(graphTitle).toBeDefined();
   });
+
+  test('データがない時にメッセージが表示されるか', () => {
+    render(<PopulationChart data={[]} populationType="総人口" years={years} />);
+
+    const message = screen.queryByText('都道府県を選択してください');
+
+    expect(message).toBeDefined();
+  });
+
+  test('データがある時にメッセージが表示されないか', () => {
+    render(<PopulationChart data={data} populationType="総人口" years={years} />);
+
+    const message = screen.queryByText('都道府県を選択してください');
+
+    expect(message).toBeNull();
+  });
 });

--- a/src/app/_components/ChartSection/Chart/index.tsx
+++ b/src/app/_components/ChartSection/Chart/index.tsx
@@ -40,7 +40,15 @@ export default function PopulationChart(props: Props): ReactElement {
     <section className={styles.section}>
       <h2>{populationType}推移</h2>
       <PopulationTypeSelector />
-      <HighchartsReact highcharts={Highcharts} options={options} />
+      <div className={styles.chart_container}>
+        {data.length === 0 && (
+          <div className={styles.message_area}>
+            <p>都道府県を選択してください</p>
+          </div>
+        )}
+
+        <HighchartsReact highcharts={Highcharts} options={options} />
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
Closes https://github.com/SatooRu65536/yumemi-codingtest/issues/33

## 説明
都道府県を見選択時にメッセージを表示

## 更新前の動作
常にチャートが表示される

## 更新後の動作
未選択時は `都道府県を選択してください` と表示されチャートは非表示にする

## 追加情報
