### PR TITLE
ESLint に next/recommended を追加

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,7 +9,8 @@
     "standard-with-typescript",
     "plugin:react/recommended",
     "prettier",
-    "plugin:storybook/recommended"
+    "plugin:storybook/recommended",
+    "plugin:@next/next/recommended"
   ],
   "parserOptions": {
     "ecmaVersion": "latest",


### PR DESCRIPTION
Closes https://github.com/SatooRu65536/yumemi-codingtest/issues/41

## 説明


## 更新前の動作
`yarn build` 時に warn がでる
```
The Next.js plugin was not detected in your ESLint configuration. See https://nextjs.org/docs/basic-features/eslint#migrating-existing-config
```

## 更新後の動作
warn 解消

## 追加情報
